### PR TITLE
clarify how to connect to non-TLS SpiceDB

### DIFF
--- a/examples/v1/App.java
+++ b/examples/v1/App.java
@@ -50,7 +50,7 @@ public class App {
     public static void main(String[] args) {
         ManagedChannel channel = ManagedChannelBuilder
                 .forTarget(target)
-                .useTransportSecurity()
+                .useTransportSecurity() // if not using TLS, replace with .usePlaintext()
                 .build();
         try {
             App client = new App(channel);


### PR DESCRIPTION
some community members struggled to get the example to work because they assumed removing `useTransportSecurity()` will fallback to `usePlaintext()` but that's no the case and needs to be added explicitly.