### PR TITLE
Bump protoc and gRPC versions for generated code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ sourceSets { main {
 
 dependencies {
   implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+  implementation "com.google.protobuf:protobuf-java:${protocVersion}"
   implementation "io.grpc:grpc-stub:${grpcVersion}"
   runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
   compileOnly "org.apache.tomcat:annotations-api:6.0.53"

--- a/build.gradle
+++ b/build.gradle
@@ -66,19 +66,25 @@ signing {
   sign publishing.publications.authzed
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
 
 java {
   withJavadocJar()
   withSourcesJar()
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.sourcesJar {
+  // This is necessary to keep gradle from barking at you
+  // about an implicit dependency between these two tasks.
+  dependsOn tasks.compileJava
 }
 
 // All it does is complain about generated code.
 javadoc { options.addStringOption('Xdoclint:none', '-quiet') }
 
 def grpcVersion = "1.66.0"
-def protocVersion = "4.27.3"
+def protocVersion = "4.27.4"
 def authzedProtoCommit = "v1.35.0"
 def bufDir = "${buildDir}/buf"
 def protocPlatformTag = project.findProperty('protoc_platform') ? ":${protoc_platform}" : ""
@@ -140,6 +146,7 @@ configurations {
     intTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
+// Test things
 dependencies {
   intTestImplementation "junit:junit:4.13.2"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,8 @@ java {
 // All it does is complain about generated code.
 javadoc { options.addStringOption('Xdoclint:none', '-quiet') }
 
-def grpcVersion = "1.65.1"
-def protocVersion = "3.25.3"
+def grpcVersion = "1.66.0"
+def protocVersion = "4.27.3"
 def authzedProtoCommit = "v1.35.0"
 def bufDir = "${buildDir}/buf"
 def protocPlatformTag = project.findProperty('protoc_platform') ? ":${protoc_platform}" : ""

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/authzed/grpcutil/BearerToken.java
+++ b/src/main/java/com/authzed/grpcutil/BearerToken.java
@@ -32,9 +32,4 @@ public class BearerToken extends CallCredentials {
             }
         });
     }
-
-    @Override
-    public void thisUsesUnstableApi() {
-        // Intentionally empty
-    }
 }


### PR DESCRIPTION
Depends on https://github.com/grpc/grpc-java/issues/11015

## Description
A customer noted a deprecation warning that they got when pulling in this library:
```
* @deprecated This class is deprecated, and slated for removal in the next Java breaking change
*     (5.x). Users should update gencode to >= 4.26.x which uses GeneratedMessage instead.
*/

@Deprecated
public abstract class GeneratedMessageV3
    extends GeneratedMessage.ExtendableMessage<GeneratedMessageV3> {
```

When I went and dug into it, we're currently on v25 of protobuf which corresponds to v3.25.x of the java protoc tooling. We want to be on v27, which is the currently-supported version.

There's more information in the support matrix here: https://protobuf.dev/support/version-support/#java

## Note
There are [breaking changes](https://protobuf.dev/news/v26/) in the v26 release, which is a version boundary that we're crossing. It seems like most of the changes are related to features of the generated code that most consumers won't be using or aware of, but it may be prudent to make this a major version bump.

## Changes
* Bump the version of the protoc plugin we're using
* Bump the gRPC version that we pull in
## Testing
Review. See that things are green.