### PR TITLE
Bump to most recent protobuf-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ tasks.sourcesJar {
 javadoc { options.addStringOption('Xdoclint:none', '-quiet') }
 
 def grpcVersion = "1.66.0"
-def protocVersion = "4.27.4"
+def protocVersion = "4.28.0"
 def authzedProtoCommit = "v1.35.0"
 def bufDir = "${buildDir}/buf"
 def protocPlatformTag = project.findProperty('protoc_platform') ? ":${protoc_platform}" : ""


### PR DESCRIPTION
Fixes #103 

## Description
`protobuf-java` 4.27 introduced a breaking change in the class references used in code generation. 4.28 introduced backwards-compatibility by reintroducing the old classes, which should provide better cross-compatibility when multiple packages that request multiple versions of protobuf are used in the same project.

## Changes
* Bump to most recent protobuf-java version

## Testing
Review. See that everything goes green.