### PR TITLE
remove v from version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Most commonly, if you are using [Maven] you can add the following to your pom.xm
     <dependency>
         <groupId>com.authzed.api</groupId>
         <artifactId>authzed</artifactId>
-        <version>v1.2.0</version>
+        <version>1.2.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>


### PR DESCRIPTION
The releases no longer contain the v prefix on version number, so the README tripped me up when trying to pull the latest version.  Hence removing the v from the README.md

![image](https://github.com/user-attachments/assets/55076d57-a70a-4bbb-bf55-5ff8bb264620)
