### PR TITLE
Improve protobuf java deps handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Most commonly, if you are using [Maven] you can add the following to your pom.xm
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-api</artifactId>
-        <version>1.71.0</version>
+        <version>1.72.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-stub</artifactId>
-        <version>1.71.0</version>
+        <version>1.72.0</version>
     </dependency>
 </dependencies>
 ```
@@ -71,8 +71,8 @@ If you are using [Gradle] then add the following to your `build.gradle` file:
 ```groovy
 dependencies {
     implementation "com.authzed.api:authzed:v1.0.0"
-    implementation 'io.grpc:grpc-api:1.71.0'
-    implementation 'io.grpc:grpc-stub:1.71.0'
+    implementation 'io.grpc:grpc-api:1.72.0'
+    implementation 'io.grpc:grpc-stub:1.72.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Most commonly, if you are using [Maven] you can add the following to your pom.xm
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
-        <artifactId>grpc-protobuf</artifactId>
-        <version>1.66.0</version>
+        <artifactId>grpc-api</artifactId>
+        <version>1.71.0</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-stub</artifactId>
-        <version>1.66.0</version>
+        <version>1.71.0</version>
     </dependency>
 </dependencies>
 ```
@@ -71,8 +71,8 @@ If you are using [Gradle] then add the following to your `build.gradle` file:
 ```groovy
 dependencies {
     implementation "com.authzed.api:authzed:v1.0.0"
-    implementation 'io.grpc:grpc-protobuf:1.66.0'
-    implementation 'io.grpc:grpc-stub:1.66.0'
+    implementation 'io.grpc:grpc-api:1.71.0'
+    implementation 'io.grpc:grpc-stub:1.71.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,9 @@ sourceSets { main {
 }}
 
 dependencies {
-  implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+  implementation("io.grpc:grpc-protobuf:${grpcVersion}") {
+    exclude group: 'com.google.protobuf', module: 'protobuf-java'
+  }
   implementation "com.google.protobuf:protobuf-java:${protocVersion}"
   implementation "io.grpc:grpc-stub:${grpcVersion}"
   runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ tasks.sourcesJar {
 // All it does is complain about generated code.
 javadoc { options.addStringOption('Xdoclint:none', '-quiet') }
 
-def grpcVersion = "1.71.0"
+def grpcVersion = "1.72.0"
 def protocVersion = "4.30.2"
 def authzedProtoCommit = "v1.41.0"
 def bufDir = "${buildDir}/buf"

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ dependencies {
   implementation("io.grpc:grpc-protobuf:${grpcVersion}") {
     exclude group: 'com.google.protobuf', module: 'protobuf-java'
   }
-  implementation "com.google.protobuf:protobuf-java:${protocVersion}"
+  api "com.google.protobuf:protobuf-java:${protocVersion}"
   implementation "io.grpc:grpc-stub:${grpcVersion}"
   runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
   compileOnly "org.apache.tomcat:annotations-api:6.0.53"

--- a/examples/v1/App.java
+++ b/examples/v1/App.java
@@ -7,23 +7,24 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.authzed.api.v1.Core;
-import com.authzed.api.v1.Core.ObjectReference;
-import com.authzed.api.v1.Core.Relationship;
-import com.authzed.api.v1.Core.SubjectReference;
-import com.authzed.api.v1.Core.ZedToken;
-import com.authzed.api.v1.PermissionService;
-import com.authzed.api.v1.PermissionService.CheckPermissionRequest;
-import com.authzed.api.v1.PermissionService.Consistency;
-import com.authzed.api.v1.PermissionService.CheckPermissionResponse.Permissionship;
+import com.authzed.api.v1.CheckPermissionRequest;
+import com.authzed.api.v1.CheckPermissionResponse;
+import com.authzed.api.v1.CheckPermissionResponse.Permissionship;
+import com.authzed.api.v1.Consistency;
+import com.authzed.api.v1.ObjectReference;
 import com.authzed.api.v1.PermissionsServiceGrpc;
+import com.authzed.api.v1.ReadSchemaRequest;
+import com.authzed.api.v1.ReadSchemaResponse;
+import com.authzed.api.v1.Relationship;
+import com.authzed.api.v1.RelationshipUpdate;
 import com.authzed.api.v1.SchemaServiceGrpc;
-import com.authzed.api.v1.SchemaServiceOuterClass.ReadSchemaRequest;
-import com.authzed.api.v1.SchemaServiceOuterClass.ReadSchemaResponse;
-import com.authzed.api.v1.SchemaServiceOuterClass.WriteSchemaRequest;
-import com.authzed.api.v1.SchemaServiceOuterClass.WriteSchemaResponse;
+import com.authzed.api.v1.SubjectReference;
+import com.authzed.api.v1.WriteRelationshipsRequest;
+import com.authzed.api.v1.WriteRelationshipsResponse;
+import com.authzed.api.v1.WriteSchemaRequest;
+import com.authzed.api.v1.WriteSchemaResponse;
+import com.authzed.api.v1.ZedToken;
 import com.authzed.grpcutil.BearerToken;
-
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -124,10 +125,10 @@ public class App {
     public String writeRelationship() {
         logger.info("Write relationship...");
 
-        PermissionService.WriteRelationshipsRequest request = PermissionService.WriteRelationshipsRequest.newBuilder()
+        WriteRelationshipsRequest request = WriteRelationshipsRequest.newBuilder()
                 .addUpdates(
-                        com.authzed.api.v1.Core.RelationshipUpdate.newBuilder()
-                                .setOperation(Core.RelationshipUpdate.Operation.OPERATION_CREATE)
+                        RelationshipUpdate.newBuilder()
+                                .setOperation(RelationshipUpdate.Operation.OPERATION_CREATE)
                                 .setRelationship(
                                         Relationship.newBuilder()
                                                 .setResource(
@@ -148,7 +149,7 @@ public class App {
                                 .build())
                 .build();
 
-        PermissionService.WriteRelationshipsResponse response;
+        WriteRelationshipsResponse response;
         try {
             response = permissionsService.writeRelationships(request);
         } catch (Exception e) {
@@ -162,7 +163,7 @@ public class App {
     public Permissionship check(ZedToken zedToken) {
         logger.info("Checking...");
 
-        PermissionService.CheckPermissionRequest request = CheckPermissionRequest.newBuilder()
+        CheckPermissionRequest request = CheckPermissionRequest.newBuilder()
                 .setConsistency(
                         Consistency.newBuilder()
                                 .setAtLeastAsFresh(zedToken)
@@ -183,12 +184,12 @@ public class App {
                 .setPermission("can_comment")
                 .build();
 
-        PermissionService.CheckPermissionResponse response;
+        CheckPermissionResponse response;
         try {
             response = permissionsService.checkPermission(request);
         } catch (Exception e) {
             logger.log(Level.WARNING, "RPC failed: {0}", e.getMessage());
-            return "";
+            return null;
         }
         logger.info("Response: " + response.toString());
         return response.getPermissionship();


### PR DESCRIPTION
1. Exclude conflicting transitive version of protobuf-java
2. Include protobuf-java as a compile dependency to consumers can more easily compile their applications.
3. Update sample code to make sure it compiles (not compileable since [0.8.0](https://github.com/authzed/authzed-java/releases/tag/0.8.0) was released)
4. Update README with versions of io.grpc libraries that match gradle config.