### PR TITLE
Add protovalidate proto to build step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,20 +105,8 @@ dependencies {
   compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 }
 
-task validateProtos(type: Exec) {
-  mkdir bufDir
-  commandLine("buf", "export", "--exclude-imports", "buf.build/envoyproxy/protoc-gen-validate", "-o", bufDir)
-}
-
-task gatewayProtos(type: Exec) {
-  mkdir bufDir
-  commandLine("buf", "export", "--exclude-imports", "buf.build/grpc-ecosystem/grpc-gateway", "-o", bufDir)
-}
-
 task authzedProtos(type: Exec) {
-  dependsOn validateProtos
-  dependsOn gatewayProtos
-  commandLine("buf", "export", "--exclude-imports", "buf.build/authzed/api:${authzedProtoCommit}", "-o", bufDir)
+  commandLine("buf", "export", "buf.build/authzed/api:${authzedProtoCommit}", "-o", bufDir)
 }
 
 protobuf {


### PR DESCRIPTION
## Description
Since the last time `authzed-java`'s API defs were updated, we added [protovalidate](https://protovalidate.com) to the definitions. This should make for a better experience validating protos in client code, but also requires additional proto to be brought in for the build step. You can see the errors that we hit [here](https://github.com/authzed/authzed-java/actions/runs/17278577246/job/49041546572#step:6:61).

## Changes
* Bring in the missing proto by removing `--exclude-imports` and letting buf take care of things
## Testing
Review