### PR TITLE
Fix sonatype publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,13 @@ repositories {
 group = "com.authzed.api"
 version = findProperty("release") ?: "0.0.0-SNAPSHOT"
 
-nexusPublishing { repositories { sonatype {
-  // If registered in Sonatype after 24 Feb 2021, you must explicitly configure these:
-  nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-  snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+nexusPublishing {
+  repositories {
+    sonatype {
+      // Docs here:
+      // https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
 }}}
 
 publishing {


### PR DESCRIPTION
## Description
Based on [this comment](https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-ossrh), it looks like our maven publishing has been broken since the end of June. This should fix it by configuring according to the plugin's instructions.

## Changes
* Update gradle to follow instructions
* Reformat a bit
## Testing
Review.