### PR TITLE
chore: drop JDK 8 from integration test matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,6 @@ jobs:
     strategy:
       matrix:
         java: # https://endoflife.date/oracle-jdk
-          - 8 # Oldest
           - 21 # LTS
           - 24 # Latest
     name: "Java ${{ matrix.java }} Test"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,8 +42,9 @@ jobs:
     strategy:
       matrix:
         java: # https://endoflife.date/oracle-jdk
+          - 17 # Oldest
           - 21 # LTS
-          - 24 # Latest
+          - 25 # Latest (though also LTS)
     name: "Java ${{ matrix.java }} Test"
     steps:
       - uses: "actions/checkout@v6"


### PR DESCRIPTION
## Summary
- Remove `- 8 # Oldest` from the `test` matrix in `.github/workflows/build.yaml`.
- Fixes the `Java 8 Test` job that's been failing since the Gradle 9.3.1 wrapper bump in `91809c3`.

## Why
Gradle 9.x dropped JDK 8 support for *running* the Gradle daemon, so the `Java 8 Test` job fails immediately with:
```
Gradle requires JVM 17 or later to run. Your build is currently configured to use JVM 8.
```
The library's bytecode target also moved to JDK 17 in `452e52d chore: fix gradle warnings` (`sourceCompatibility/targetCompatibility = VERSION_17`), so the artifact can't run on JDK 8 at runtime either. The matrix entry is dead weight that just turns every PR red.

Failing run: https://github.com/authzed/authzed-java/actions/runs/26462262774/job/77913010022

The `build` matrix is already JDK 17 / 21 / 25 — no JDK 8 there to remove.

## Test plan
- [ ] PR's own CI passes (Java 21 Test, Java 24 Test, all three Build jobs).